### PR TITLE
Add `choose_any` and `choose_all` methods

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -15,5 +15,6 @@ dependencies:
   - pytest-xdist
   - xarray>=0.18
   - zarr
+  - toolz
   - pip:
       - -r ../requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pydantic
 xarray
+toolz

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ extend-ignore = E203,E501,E402,W605
 
 [isort]
 known_first_party=xcollection
-known_third_party=pkg_resources,pydantic,pytest,setuptools,xarray
+known_third_party=pkg_resources,pydantic,pytest,setuptools,toolz,xarray
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -75,7 +75,7 @@ def test_iter():
 @pytest.mark.parametrize('data_vars', ['Tair', ['Tair']])
 def test_choose_all(data_vars):
     c = xcollection.Collection({'foo': ds, 'bar': ds})
-    d = c.choose_all(data_vars)
+    d = c.choose(data_vars, mode='all')
     assert c == d
     assert set(d.keys()) == {'foo', 'bar'}
 
@@ -83,11 +83,17 @@ def test_choose_all(data_vars):
 def test_choose_all_error():
     c = xcollection.Collection({'foo': ds, 'bar': dsa})
     with pytest.raises(KeyError):
-        c.choose_all('Tair')
+        c.choose('Tair', mode='all')
+
+
+def test_choose_mode_error():
+    c = xcollection.Collection()
+    with pytest.raises(ValueError):
+        c.choose('Tair', mode='foo')
 
 
 @pytest.mark.parametrize('data_vars', ['Tair', ['air']])
 def test_choose_any(data_vars):
     c = xcollection.Collection({'foo': ds, 'bar': dsa})
-    d = c.choose_any(data_vars)
+    d = c.choose(data_vars, mode='any')
     assert len(d) == 1

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,6 +7,7 @@ import xarray as xr
 import xcollection
 
 ds = xr.tutorial.open_dataset('rasm')
+dsa = xr.tutorial.open_dataset('air_temperature')
 
 
 @pytest.mark.parametrize('datasets', [None, {'a': ds, 'b': ds}, {'test': ds.Tair}])
@@ -69,3 +70,24 @@ def test_getitem():
 def test_iter():
     c = xcollection.Collection()
     assert isinstance(iter(c), typing.Iterator)
+
+
+@pytest.mark.parametrize('data_vars', ['Tair', ['Tair']])
+def test_choose_all(data_vars):
+    c = xcollection.Collection({'foo': ds, 'bar': ds})
+    d = c.choose_all(data_vars)
+    assert c == d
+    assert set(d.keys()) == {'foo', 'bar'}
+
+
+def test_choose_all_error():
+    c = xcollection.Collection({'foo': ds, 'bar': dsa})
+    with pytest.raises(KeyError):
+        c.choose_all('Tair')
+
+
+@pytest.mark.parametrize('data_vars', ['Tair', ['air']])
+def test_choose_any(data_vars):
+    c = xcollection.Collection({'foo': ds, 'bar': dsa})
+    d = c.choose_any(data_vars)
+    assert len(d) == 1

--- a/xcollection/main.py
+++ b/xcollection/main.py
@@ -106,21 +106,16 @@ class Collection(MutableMapping):
         if isinstance(data_vars, str):
             data_vars = [data_vars]
 
-        def _select_all(dset):
+        def _select_vars(dset):
             try:
                 return dset[data_vars]
             except KeyError:
-                raise KeyError(f'No data variables: `{data_vars}` found in dataset: {dset!r}')
-
-        def _select_any(dset):
-            try:
-                return dset[data_vars]
-            except KeyError:
-                pass
+                if mode == 'all':
+                    raise KeyError(f'No data variables: `{data_vars}` found in dataset: {dset!r}')
 
         if mode == 'all':
-            result = toolz.valmap(_select_all, self.datasets)
+            result = toolz.valmap(_select_vars, self.datasets)
         elif mode == 'any':
-            result = toolz.valfilter(_select_any, self.datasets)
+            result = toolz.valfilter(_select_vars, self.datasets)
 
         return type(self)(datasets=result)

--- a/xcollection/main.py
+++ b/xcollection/main.py
@@ -82,7 +82,7 @@ class Collection(MutableMapping):
         return self.datasets.items()
 
     def choose(
-        self, data_vars: typing.Union[str, typing.List[str]], mode: str = 'all'
+        self, data_vars: typing.Union[str, typing.List[str]], *, mode: str = 'any'
     ) -> 'Collection':
         """Return a collection with datasets containing all or any of the specified data variables.
         Parameters
@@ -90,7 +90,7 @@ class Collection(MutableMapping):
         data_vars : str or list of str
             The data variables to select on.
         mode : str, optional
-            The selection mode. Must be one of 'all' or 'any'.
+            The selection mode. Must be one of 'all' or 'any'. Defaults to 'any'.
 
         Returns
         -------

--- a/xcollection/main.py
+++ b/xcollection/main.py
@@ -82,9 +82,7 @@ class Collection(MutableMapping):
         return self.datasets.items()
 
     def choose_all(self, data_vars: typing.Union[str, typing.List[str]]) -> 'Collection':
-        """
-        Return a dataset containing all the data variables in the collection.
-        """
+        """Return a collection with datasets containing all of the specified data variables."""
         if isinstance(data_vars, str):
             data_vars = [data_vars]
 
@@ -98,9 +96,7 @@ class Collection(MutableMapping):
         return type(self)(datasets=result)
 
     def choose_any(self, data_vars: typing.Union[str, typing.List[str]]) -> 'Collection':
-        """
-        Return a dataset containing any of the data variables in the collection.
-        """
+        """Return a collection with datasets containing any of the specified data variables."""
         if isinstance(data_vars, str):
             data_vars = [data_vars]
 


### PR DESCRIPTION

```python
In [1]: import xarray as xr, xcollection

In [2]: ds = xr.tutorial.open_dataset('rasm')

In [3]: ds.attrs = {}

In [4]: dsa = xr.tutorial.open_dataset('air_temperature')

In [5]: dsa.attrs = {}

In [6]: c = xcollection.Collection({'foo': ds, 'bar': dsa})

In [7]: c
Out[7]: 
<Collection (2 keys)>
🔑 foo
<xarray.Dataset>
Dimensions:  (time: 36, y: 205, x: 275)
Coordinates:
  * time     (time) object 1980-09-16 12:00:00 ... 1983-08-17 00:00:00
    xc       (y, x) float64 ...
    yc       (y, x) float64 ...
Dimensions without coordinates: y, x
Data variables:
    Tair     (time, y, x) float64 ...

🔑 bar
<xarray.Dataset>
Dimensions:  (lat: 25, time: 2920, lon: 53)
Coordinates:
  * lat      (lat) float32 75.0 72.5 70.0 67.5 65.0 ... 25.0 22.5 20.0 17.5 15.0
  * lon      (lon) float32 200.0 202.5 205.0 207.5 ... 322.5 325.0 327.5 330.0
  * time     (time) datetime64[ns] 2013-01-01 ... 2014-12-31T18:00:00
Data variables:
    air      (time, lat, lon) float32 ...

```

- **Choose ANY**

```python
In [8]: c.choose_any('air')
Out[8]: 
<Collection (1 keys)>
🔑 bar
<xarray.Dataset>
Dimensions:  (lat: 25, time: 2920, lon: 53)
Coordinates:
  * lat      (lat) float32 75.0 72.5 70.0 67.5 65.0 ... 25.0 22.5 20.0 17.5 15.0
  * lon      (lon) float32 200.0 202.5 205.0 207.5 ... 322.5 325.0 327.5 330.0
  * time     (time) datetime64[ns] 2013-01-01 ... 2014-12-31T18:00:00
Data variables:
    air      (time, lat, lon) float32 ...


In [9]: c.choose_any(['air', 'Tair'])
Out[9]: <Collection (0 keys)>

```

- **Choose ALL**

```python
In [10]: c.choose_all('air')
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
~/.mambaforge/envs/xcollection-dev/lib/python3.9/site-packages/xarray/core/dataset.py in _copy_listed(self, names)
   1362             try:
-> 1363                 variables[name] = self._variables[name]
   1364             except KeyError:

KeyError: 'air'

During handling of the above exception, another exception occurred:

KeyError                                  Traceback (most recent call last)
~/devel/ncar/xcollection/xcollection/main.py in _select_vars(dset)
     92             try:
---> 93                 return dset[data_vars]
     94             except KeyError:

~/.mambaforge/envs/xcollection-dev/lib/python3.9/site-packages/xarray/core/dataset.py in __getitem__(self, key)
   1503         else:
-> 1504             return self._copy_listed(key)
   1505 

~/.mambaforge/envs/xcollection-dev/lib/python3.9/site-packages/xarray/core/dataset.py in _copy_listed(self, names)
   1364             except KeyError:
-> 1365                 ref_name, var_name, var = _get_virtual_variable(
   1366                     self._variables, name, self._level_coords, self.dims

~/.mambaforge/envs/xcollection-dev/lib/python3.9/site-packages/xarray/core/dataset.py in _get_virtual_variable(variables, key, level_vars, dim_sizes)
    172     else:
--> 173         ref_var = variables[ref_name]
    174 

KeyError: 'air'

During handling of the above exception, another exception occurred:

KeyError                                  Traceback (most recent call last)
<ipython-input-10-056950f9daff> in <module>
----> 1 c.choose_all('air')

~/devel/ncar/xcollection/xcollection/main.py in choose_all(self, data_vars)
     95                 raise KeyError(f'No data variables: `{data_vars}` found in dataset: {dset!r}')
     96 
---> 97         result = toolz.valmap(_select_vars, self.datasets)
     98         return type(self)(datasets=result)
     99 

~/.mambaforge/envs/xcollection-dev/lib/python3.9/site-packages/toolz/dicttoolz.py in valmap(func, d, factory)
     81     """
     82     rv = factory()
---> 83     rv.update(zip(d.keys(), map(func, d.values())))
     84     return rv
     85 

~/devel/ncar/xcollection/xcollection/main.py in _select_vars(dset)
     93                 return dset[data_vars]
     94             except KeyError:
---> 95                 raise KeyError(f'No data variables: `{data_vars}` found in dataset: {dset!r}')
     96 
     97         result = toolz.valmap(_select_vars, self.datasets)

KeyError: "No data variables: `['air']` found in dataset: <xarray.Dataset>\nDimensions:  (time: 36, y: 205, x: 275)\nCoordinates:\n  * time     (time) object 1980-09-16 12:00:00 ... 1983-08-17 00:00:00\n    xc       (y, x) float64 ...\n    yc       (y, x) float64 ...\nDimensions without coordinates: y, x\nData variables:\n    Tair     (time, y, x) float64 ..."
```