### PR TITLE
Add Collection.plot() function

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+matplotlib
 pydantic
 xarray
 toolz

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ extend-ignore = E203,E501,E402,W605
 
 [isort]
 known_first_party=xcollection
-known_third_party=pkg_resources,pydantic,pytest,setuptools,toolz,xarray
+known_third_party=matplotlib,pkg_resources,pydantic,pytest,setuptools,toolz,xarray
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0

--- a/xcollection/main.py
+++ b/xcollection/main.py
@@ -27,9 +27,16 @@ def _validate_input(value):
     return value
 
 
-def _make_plot(var, key, ds):
+def _make_plot(var, isel_dict, key, ds):
+    # Are all dims in isel_dict in ds?
+    if len(set(isel_dict.keys()) - set(ds.dims)) > 0:
+        return False
+
+    # Is ds a dataset? If so, does it contain var?
     if type(ds) == xr.Dataset:
         return var in ds.variables
+
+    # Is ds a DataArray? If so, is its name var?
     if type(ds) == xr.DataArray:
         return var == ds.name
     return False
@@ -208,11 +215,11 @@ class Collection(MutableMapping):
 
         return_dict = {}
         for key, data in self.items():
-            if _make_plot(var, key, data):
+            if _make_plot(var, isel_dict, key, data):
                 fig = plt.figure(figsize=figsize)
                 axes = fig.add_subplot()
                 if type(data) == xr.Dataset:
-                    data[var].isel(isel_dict).plot(ax=axes, *args, **kwargs)
+                    data.isel(isel_dict)[var].plot(ax=axes, *args, **kwargs)
                 if type(data) == xr.DataArray:
                     data.isel(isel_dict).plot(ax=axes, *args, **kwargs)
                 return_dict[key] = fig

--- a/xcollection/main.py
+++ b/xcollection/main.py
@@ -2,10 +2,10 @@ import typing
 from collections.abc import MutableMapping
 
 import matplotlib
-from matplotlib import pyplot as plt
 import pydantic
 import toolz
 import xarray as xr
+from matplotlib import pyplot as plt
 
 
 def _rpartial(func, *args, **kwargs):
@@ -22,7 +22,9 @@ def _rpartial(func, *args, **kwargs):
 
 def _validate_input(value):
     if not isinstance(value, (xr.Dataset, xr.DataArray, matplotlib.figure.Figure)):
-        raise TypeError(f'Expected an xarray.Dataset, xarray.DataArray, or matplotlib type, got {type(value)}')
+        raise TypeError(
+            f'Expected an xarray.Dataset, xarray.DataArray, or matplotlib type, got {type(value)}'
+        )
     if isinstance(value, xr.DataArray):
         return value.to_dataset()
     return value
@@ -35,12 +37,14 @@ class Config:
 
 @pydantic.dataclasses.dataclass(config=Config)
 class Collection(MutableMapping):
-    datasets: typing.Dict[pydantic.StrictStr,
-                          typing.Union[xr.Dataset,
-                                       xr.DataArray,
-                                       matplotlib.figure.Figure,
-                                      ]
-                         ] = None
+    datasets: typing.Dict[
+        pydantic.StrictStr,
+        typing.Union[
+            xr.Dataset,
+            xr.DataArray,
+            matplotlib.figure.Figure,
+        ],
+    ] = None
 
     @pydantic.validator('datasets', pre=True, each_item=True)
     def _validate_datasets(cls, value):

--- a/xcollection/main.py
+++ b/xcollection/main.py
@@ -1,7 +1,6 @@
 import typing
 from collections.abc import MutableMapping
 
-import matplotlib
 import pydantic
 import toolz
 import xarray as xr
@@ -21,10 +20,8 @@ def _rpartial(func, *args, **kwargs):
 
 
 def _validate_input(value):
-    if not isinstance(value, (xr.Dataset, xr.DataArray, matplotlib.figure.Figure)):
-        raise TypeError(
-            f'Expected an xarray.Dataset, xarray.DataArray, or matplotlib type, got {type(value)}'
-        )
+    if not isinstance(value, (xr.Dataset, xr.DataArray)):
+        raise TypeError(f'Expected an xarray.Dataset or xarray.DataArray, got {type(value)}')
     if isinstance(value, xr.DataArray):
         return value.to_dataset()
     return value
@@ -37,14 +34,7 @@ class Config:
 
 @pydantic.dataclasses.dataclass(config=Config)
 class Collection(MutableMapping):
-    datasets: typing.Dict[
-        pydantic.StrictStr,
-        typing.Union[
-            xr.Dataset,
-            xr.DataArray,
-            matplotlib.figure.Figure,
-        ],
-    ] = None
+    datasets: typing.Dict[pydantic.StrictStr, typing.Union[xr.Dataset, xr.DataArray]] = None
 
     @pydantic.validator('datasets', pre=True, each_item=True)
     def _validate_datasets(cls, value):
@@ -193,4 +183,4 @@ class Collection(MutableMapping):
                 ds[var].isel(isel_dict).plot(ax=axes, *args, **kwargs)
                 return_dict[key] = fig
                 print(type(return_dict[key]))
-        return Collection(return_dict)
+        return return_dict

--- a/xcollection/main.py
+++ b/xcollection/main.py
@@ -222,5 +222,5 @@ class Collection(MutableMapping):
                     data.isel(isel_dict)[var].plot(ax=axes, *args, **kwargs)
                 if type(data) == xr.DataArray:
                     data.isel(isel_dict).plot(ax=axes, *args, **kwargs)
-                return_dict[key] = fig
+                return_dict[key] = (fig, axes)
         return return_dict


### PR DESCRIPTION
As a first pass, I allow `Collections` to contain `matplotlib.figure.Figure`
objects. `Collection.plot()` requires a variable argument (for now a string, but
perhaps a list of variables to plot would be better?) and also allows the user
to pass `isel_dict` to help reduce dimensions. There is a trello card about
introducing `sel` / `isel` functionality, and once that's done the `isel_dict`
argument can be removed.

I like the idea of being able to super-impose line plots (time series of scalar
quantities, or vertical profiles) in a single figure, but I have not made any
progress on that front yet.

I also should add a test for this function.

Fixes #13 