### PR TITLE
Add keymap method

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -113,6 +113,15 @@ def test_map(dim, attrs):
     xr.testing.assert_identical(d['foo'], func(dsa, 'air', attrs=attrs, dim=dim).to_dataset())
 
 
+def test_keymap():
+    c = xcollection.Collection({'foo': ds, 'bar': ds})
+    d = c.keymap(lambda k: k.upper())
+    assert set(d.keys()) == {'FOO', 'BAR'}
+
+    with pytest.raises(TypeError):
+        c.keymap('TEST')
+
+
 def test_map_type_error():
     c = xcollection.Collection()
     with pytest.raises(TypeError):

--- a/xcollection/main.py
+++ b/xcollection/main.py
@@ -132,6 +132,24 @@ class Collection(MutableMapping):
 
         return type(self)(datasets=result)
 
+    def keymap(self, func: typing.Callable[[str], str]) -> 'Collection':
+        """Apply a function to each key in the collection.
+        Parameters
+        ----------
+        func : callable
+            The function to apply to each key.
+
+        Returns
+        -------
+        Collection
+            A new collection containing the results of the function.
+
+        """
+        if not callable(func):
+            raise TypeError(f'First argument must be callable function, got {type(func)}')
+
+        return type(self)(datasets=toolz.keymap(func, self.datasets))
+
     def map(
         self,
         func: typing.Callable[[xr.Dataset], xr.Dataset],


### PR DESCRIPTION
This PR adds a `keymap` method which allows manipulating the keys in the collection